### PR TITLE
Add server to serve redirect landing

### DIFF
--- a/lib/actions/perform_auth.go
+++ b/lib/actions/perform_auth.go
@@ -5,16 +5,22 @@ import (
 
 	"github.com/Coteh/gyroid/lib/connector"
 	"github.com/Coteh/gyroid/lib/utils"
+
+	"net/http"
+	"net/http/httptest"
 )
 
 // PerformAuth performs authentication with Pocket to retrieve an access token for the user
-func PerformAuth(client connector.PocketConnector, delayMs time.Duration, redirectURI string, browserOpenFunc func(string)) (string, error) {
-	code, err := client.RequestOAuthCode(redirectURI)
+func PerformAuth(client connector.PocketConnector, delayMs time.Duration, browserOpenFunc func(string)) (string, error) {
+	ts := launchRedirectServer()
+	defer ts.Close()
+
+	code, err := client.RequestOAuthCode(ts.URL)
 	if err != nil {
 		return "", err
 	}
 
-	utils.OpenAuthURL(code, redirectURI, browserOpenFunc)
+	utils.OpenAuthURL(code, ts.URL, browserOpenFunc)
 
 	time.Sleep(delayMs * time.Millisecond)
 
@@ -24,4 +30,13 @@ func PerformAuth(client connector.PocketConnector, delayMs time.Duration, redire
 	}
 
 	return accessToken, nil
+}
+
+func launchRedirectServer() *httptest.Server {
+	return httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(200)
+			w.Write([]byte("Pocket user has been authorized. Close this window and go back to the app."))
+		}),
+	)
 }

--- a/main.go
+++ b/main.go
@@ -88,10 +88,6 @@ func handleConfigFileError(filePath string) *config.Config {
 
 func initializePocketConnection() *connector.PocketClient {
 	consumerKey := os.Getenv("POCKET_CONSUMER_KEY")
-	redirectURI := os.Getenv("REDIRECT_URI")
-	if redirectURI == "" {
-		redirectURI = "localhost:8000"
-	}
 
 	pocketAuth := &PocketAuth{}
 
@@ -110,7 +106,7 @@ func initializePocketConnection() *connector.PocketClient {
 
 	if accessToken == "" {
 		fmt.Println("Creating new access token")
-		accessToken, err = actions.PerformAuth(pocketClient, 3000, redirectURI, utils.OpenBrowser)
+		accessToken, err = actions.PerformAuth(pocketClient, 3000, utils.OpenBrowser)
 		if err != nil {
 			log.Fatal("Authentication with Pocket failed", err)
 		}

--- a/test/actions/perform_auth_test.go
+++ b/test/actions/perform_auth_test.go
@@ -2,6 +2,7 @@ package actions_test
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/Coteh/gyroid/lib/actions"
@@ -14,7 +15,7 @@ const CODE_FIXTURE = "oauthCode"
 const REDIRECT_URI_FIXTURE = "http://localhost:8080"
 const ACCESS_TOKEN_FIXTURE = "accessToken"
 const DELAY_MILLISECONDS = 0
-const EXPECTED_AUTH_URL = "https://getpocket.com/auth/authorize?request_token=" + CODE_FIXTURE + "&redirect_uri=" + REDIRECT_URI_FIXTURE
+const EXPECTED_AUTH_URL_PREFIX = "https://getpocket.com/auth/authorize?request_token=" + CODE_FIXTURE
 
 func openURLStub(redirectUri string) {}
 
@@ -22,40 +23,40 @@ func TestPerformAuthPerformsAuth(t *testing.T) {
 	mockClient := CreatePocketClientMock()
 	mockClient.On("RequestOAuthCode", mock.Anything).Return(CODE_FIXTURE, nil)
 	mockClient.On("Authorize", mock.Anything).Return(ACCESS_TOKEN_FIXTURE, nil)
-	result, _ := actions.PerformAuth(mockClient, DELAY_MILLISECONDS, REDIRECT_URI_FIXTURE, openURLStub)
+	result, _ := actions.PerformAuth(mockClient, DELAY_MILLISECONDS, openURLStub)
 	assert.Equal(t, ACCESS_TOKEN_FIXTURE, result)
 }
 
 func TestPerformAuthCallsAuthorizeWithCorrectParams(t *testing.T) {
 	mockClient := CreatePocketClientMock()
-	mockClient.On("RequestOAuthCode", REDIRECT_URI_FIXTURE).Return(CODE_FIXTURE, nil)
+	mockClient.On("RequestOAuthCode", mock.Anything).Return(CODE_FIXTURE, nil)
 	mockClient.On("Authorize", CODE_FIXTURE).Return(ACCESS_TOKEN_FIXTURE, nil)
-	actions.PerformAuth(mockClient, DELAY_MILLISECONDS, REDIRECT_URI_FIXTURE, openURLStub)
+	actions.PerformAuth(mockClient, DELAY_MILLISECONDS, openURLStub)
 }
 
 func TestPerformAuthReturnsErrorOnAuthorizeFailure(t *testing.T) {
 	mockClient := CreatePocketClientMock()
-	mockClient.On("RequestOAuthCode", REDIRECT_URI_FIXTURE).Return(CODE_FIXTURE, nil)
+	mockClient.On("RequestOAuthCode", mock.Anything).Return(CODE_FIXTURE, nil)
 	mockClient.On("Authorize", CODE_FIXTURE).Return("", errors.New(MOCK_ERROR_STRING))
-	result, err := actions.PerformAuth(mockClient, DELAY_MILLISECONDS, REDIRECT_URI_FIXTURE, openURLStub)
+	result, err := actions.PerformAuth(mockClient, DELAY_MILLISECONDS, openURLStub)
 	assert.Empty(t, result)
 	assert.Equal(t, MOCK_ERROR_STRING, err.Error())
 }
 
 func TestPerformAuthReturnsErrorOnRequestOAuthCodeFailure(t *testing.T) {
 	mockClient := CreatePocketClientMock()
-	mockClient.On("RequestOAuthCode", REDIRECT_URI_FIXTURE).Return("", errors.New(MOCK_ERROR_STRING))
-	result, err := actions.PerformAuth(mockClient, DELAY_MILLISECONDS, REDIRECT_URI_FIXTURE, openURLStub)
+	mockClient.On("RequestOAuthCode", mock.Anything).Return("", errors.New(MOCK_ERROR_STRING))
+	result, err := actions.PerformAuth(mockClient, DELAY_MILLISECONDS, openURLStub)
 	assert.Empty(t, result)
 	assert.Equal(t, MOCK_ERROR_STRING, err.Error())
 }
 
 func TestPerformAuthCallsOpenURLCorrectly(t *testing.T) {
-	openURLMock := func(redirectUri string) {
-		assert.Equal(t, EXPECTED_AUTH_URL, redirectUri)
+	openURLMock := func(url string) {
+		assert.True(t, strings.HasPrefix(url, EXPECTED_AUTH_URL_PREFIX))
 	}
 	mockClient := CreatePocketClientMock()
 	mockClient.On("RequestOAuthCode", mock.Anything).Return(CODE_FIXTURE, nil)
 	mockClient.On("Authorize", mock.Anything).Return(ACCESS_TOKEN_FIXTURE, nil)
-	actions.PerformAuth(mockClient, DELAY_MILLISECONDS, REDIRECT_URI_FIXTURE, openURLMock)
+	actions.PerformAuth(mockClient, DELAY_MILLISECONDS, openURLMock)
 }


### PR DESCRIPTION
There's now a server spun up using `net/http/httptest` library that gives a nice message to the user that they've been authenticated. No more redirect URI.