### PR TITLE
Move consumer key to seaprate file outside of project directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,7 @@ go get -u github.com/Coteh/gyroid
 
 You will need a Pocket API consumer key to use `gyroid`. You can grab one [here](https://getpocket.com/developer/apps/new).
 
-You will then need to create a textfile in `~/.config/gyroid` (where `~` is your home directory) called `consumer_key` and simply provide the consumer key in the file like this:
-
-```
-{API KEY from above step}
-```
+You will then need to create a textfile in `~/.config/gyroid` (where `~` is your home directory) called `consumer_key` and simply paste the consumer key into it.
 
 Now you can run the program from your terminal (assuming GOPATH is in your PATH) as follows:
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ go get -u github.com/Coteh/gyroid
 
 You will need a Pocket API consumer key to use `gyroid`. You can grab one [here](https://getpocket.com/developer/apps/new).
 
-You will then need to specify an environment variable `POCKET_CONSUMER_KEY` containing the consumer key you obtained from the previous step. You can create an `.env` file and fill it in like this:
+You will then need to create a textfile in `~/.config/gyroid` (where `~` is your home directory) called `consumer_key` and simply provide the consumer key in the file like this:
 
 ```
-POCKET_CONSUMER_KEY={API KEY from above step}
+{API KEY from above step}
 ```
 
 Now you can run the program from your terminal (assuming GOPATH is in your PATH) as follows:

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/Coteh/gyroid
 
 require (
 	github.com/atotto/clipboard v0.1.2
-	github.com/joho/godotenv v1.3.0
 	github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 // indirect
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
-github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024 h1:rBMNdlhTLzJjJSDIjNEXX1Pz3Hmwmz91v+zycvx9PJc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ type PocketAuth struct {
 func loadConsumerKey() string {
 	consumerKeyFilePath := filepath.Join(getConfigSubfolderPath(), CONSUMER_KEY_FILE_NAME)
 	file, err := os.Open(consumerKeyFilePath)
+	defer file.Close()
 	if err != nil {
 		log.Fatalf("Could not find consumer key file. Please provide consumer key to %s", consumerKeyFilePath)
 	}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -15,23 +16,28 @@ import (
 	"github.com/Coteh/gyroid/lib/models"
 	"github.com/Coteh/gyroid/lib/utils"
 	"github.com/Coteh/gyroid/lib/config"
-
-	"github.com/joho/godotenv"
 )
 
 const CONFIG_SUBFOLDER_NAME = ".config/gyroid"
 const CONFIG_FILE_NAME = "config.yml"
 const AUTH_FILE_NAME = "auth.json"
+const CONSUMER_KEY_FILE_NAME = "consumer_key"
 
 type PocketAuth struct {
 	AccessToken string `json:"access_token"`
 }
 
-func loadEnvVars(isVerbose bool) {
-	err := godotenv.Load()
-	if err != nil && isVerbose {
-		log.Println("Error loading .env file. Will rely on system environment variables instead.")
+func loadConsumerKey() string {
+	consumerKeyFilePath := filepath.Join(getConfigSubfolderPath(), CONSUMER_KEY_FILE_NAME)
+	file, err := os.Open(consumerKeyFilePath)
+	if err != nil {
+		log.Fatalf("Could not find consumer key file. Please provide consumer key to %s", consumerKeyFilePath)
 	}
+	consumerKeyBytes, err := ioutil.ReadAll(file)
+	if err != nil {
+		log.Fatal("Error reading consumer key from file")
+	}
+	return string(consumerKeyBytes)
 }
 
 func getConfigSubfolderPath() string {
@@ -86,9 +92,7 @@ func handleConfigFileError(filePath string) *config.Config {
 	return configObj
 }
 
-func initializePocketConnection() *connector.PocketClient {
-	consumerKey := os.Getenv("POCKET_CONSUMER_KEY")
-
+func initializePocketConnection(consumerKey string) *connector.PocketClient {
 	pocketAuth := &PocketAuth{}
 
 	var accessToken string
@@ -307,17 +311,10 @@ func runArticleLoop(pocketClient *connector.PocketClient, articlesList *[]models
 }
 
 func main() {
-	isVerbose := false
-	for i := 1; i < len(os.Args); i++ {
-		if os.Args[i] == "-v" || os.Args[i] == "--verbose" {
-			isVerbose = true
-		}
-	}
-
-	loadEnvVars(isVerbose)
+	consumerKey := loadConsumerKey()
 	configObj := loadConfig(getConfigFilePath())
 
-	pocketClient := initializePocketConnection()
+	pocketClient := initializePocketConnection(consumerKey)
 
 	articles := make([]models.ArticleResult, 0, 10)
 


### PR DESCRIPTION
- Read consumer key from config file named `consumer_key` instead of from `.env` file from project directory
- Remove `isVerbose` flag
- Remove `godotenv` dep
- Update README to reflect new consumer key file