### PR TITLE
Add previously added url to clipboard 

### DIFF
--- a/lib/utils/clipboard_utils.go
+++ b/lib/utils/clipboard_utils.go
@@ -26,7 +26,7 @@ func (c *ClipboardManagerImpl) GetMostRecentlyAddedURL() string {
 	return c.AddedURL
 }
 
-// SetMostRecentlyAddedURL sets the URl that was most recently added
+// SetMostRecentlyAddedURL sets the URL that was most recently added
 func (c *ClipboardManagerImpl) SetMostRecentlyAddedURL(url string) {
 	c.AddedURL = url
 }

--- a/lib/utils/clipboard_utils.go
+++ b/lib/utils/clipboard_utils.go
@@ -4,22 +4,46 @@ import (
 	"github.com/atotto/clipboard"
 )
 
+// ClipboardManager is an interface for actions with the clipboard
 type ClipboardManager interface {
 	GetFromClipboard() (string, error)
+	GetMostRecentlyAddedURL() string
+	SetMostRecentlyAddedURL(url string)
 }
 
+// ClipboardManagerImpl is an implementation of ClipboardManager that uses atotto's clipboard library
 type ClipboardManagerImpl struct {
+	AddedURL string
 }
 
+// GetFromClipboard gets the clipboard text using atotto's clipboard library
 func (c *ClipboardManagerImpl) GetFromClipboard() (string, error) {
 	return clipboard.ReadAll()
 }
 
+// GetMostRecentlyAddedURL gets the URL that was most recently added
+func (c *ClipboardManagerImpl) GetMostRecentlyAddedURL() string {
+	return c.AddedURL
+}
+
+// SetMostRecentlyAddedURL sets the URl that was most recently added
+func (c *ClipboardManagerImpl) SetMostRecentlyAddedURL(url string) {
+	c.AddedURL = url
+}
+
+// IsURLInClipboard checks to see if the clipboard text is actually a URL
 func IsURLInClipboard(clipboardManager ClipboardManager) bool {
 	result, err := clipboardManager.GetFromClipboard()
 	return err == nil && IsURL(result)
 }
 
+// CheckURLMostRecentlyAdded checks to see if the text in clipboard is the same as the URL that was just added
+func CheckURLMostRecentlyAdded(clipboardManager ClipboardManager) bool {
+	result, err := clipboardManager.GetFromClipboard()
+	return err == nil && result == clipboardManager.GetMostRecentlyAddedURL()
+}
+
+// GetFromClipboard gets clipboard text from the clipboard manager
 func GetFromClipboard(clipboardManager ClipboardManager) (string, error) {
 	return clipboardManager.GetFromClipboard()
 }

--- a/main.go
+++ b/main.go
@@ -263,7 +263,7 @@ func runArticleLoop(pocketClient *connector.PocketClient, articlesList *[]models
 		case "+":
 			gotURLFromClipboard := false
 			url := ""
-			if config.Clipboard && utils.IsURLInClipboard(clipboardManager) {
+			if config.Clipboard && utils.IsURLInClipboard(clipboardManager) && !utils.CheckURLMostRecentlyAdded(clipboardManager) {
 				var err error
 				url, err = utils.GetFromClipboard(clipboardManager)
 				if err != nil {
@@ -271,6 +271,7 @@ func runArticleLoop(pocketClient *connector.PocketClient, articlesList *[]models
 				} else {
 					fmt.Printf("'%s' was found in your clipboard. Would you like to add it? [Y/n]\n", url)
 					if readYesNoFromUser() {
+						clipboardManager.SetMostRecentlyAddedURL(url)
 						gotURLFromClipboard = true
 					} else {
 						fmt.Println("Did not add URL to Pocket list.")

--- a/main.go
+++ b/main.go
@@ -274,7 +274,7 @@ func runArticleLoop(pocketClient *connector.PocketClient, articlesList *[]models
 						clipboardManager.SetMostRecentlyAddedURL(url)
 						gotURLFromClipboard = true
 					} else {
-						fmt.Println("Did not add URL to Pocket list.")
+						fmt.Println("Did not add URL from clipboard to Pocket list.")
 					}
 				}
 			}
@@ -283,6 +283,10 @@ func runArticleLoop(pocketClient *connector.PocketClient, articlesList *[]models
 				url = readUserInput(func(input string) string {
 					return strings.TrimSpace(input)
 				})
+				if url == "" {
+					fmt.Println("Did not enter a URL")
+					break
+				}
 				if !utils.IsURL(url) {
 					fmt.Println("Invalid URL")
 					break


### PR DESCRIPTION
Plus bonus of additional error message if blank string entered for URL when adding article.