### PR TITLE
Prompt user to add article if end of list/empty list reached

### DIFF
--- a/main.go
+++ b/main.go
@@ -218,9 +218,7 @@ func printSuccessfullyAddedArticle(article *models.AddedArticleResult) {
 	fmt.Printf("Success adding article: '%s' (%s)\n", article.Title, article.ResolvedURL)
 }
 
-func runArticleLoop(pocketClient *connector.PocketClient, articlesList *[]models.ArticleResult, config *config.Config, mut *sync.Mutex) {
-	clipboardManager := new(utils.ClipboardManagerImpl)
-
+func runArticleLoop(pocketClient *connector.PocketClient, articlesList *[]models.ArticleResult, config *config.Config, clipboardManager utils.ClipboardManager, mut *sync.Mutex) {
 	i := 0
 	isFav := false
 	isNext := false
@@ -318,7 +316,6 @@ func runArticleLoop(pocketClient *connector.PocketClient, articlesList *[]models
 				mut.Unlock()
 			} else {
 				article = *result.ArticleResult
-				printArticle(article, 0)
 				isNext = false
 				isFav = false
 				userMarkedFav = false
@@ -372,7 +369,7 @@ func runArticleLoop(pocketClient *connector.PocketClient, articlesList *[]models
 		} else {
 			newArticleList := []models.ArticleResult{*result.ArticleResult}
 			printSuccessfullyAddedArticle(result)
-			runArticleLoop(pocketClient, &newArticleList, config, mut)
+			runArticleLoop(pocketClient, &newArticleList, config, clipboardManager, mut)
 		}
 	} else {
 		fmt.Println("Bye")
@@ -382,6 +379,7 @@ func runArticleLoop(pocketClient *connector.PocketClient, articlesList *[]models
 func main() {
 	consumerKey := loadConsumerKey()
 	configObj := loadConfig(getFilePathFromConfigFolder(configFileName))
+	clipboardManager := new(utils.ClipboardManagerImpl)
 
 	pocketClient := initializePocketConnection(consumerKey)
 
@@ -391,7 +389,7 @@ func main() {
 
 	loadPocketArticles(pocketClient, &articles, &mut)
 
-	runArticleLoop(pocketClient, &articles, configObj, &mut)
+	runArticleLoop(pocketClient, &articles, configObj, clipboardManager, &mut)
 }
 
 func loadFromJSON(path string, v interface{}) error {


### PR DESCRIPTION
Implements #20

Config option was originally planned for this PR, but holding off for now since there's not much of a benefit for having the option (depending on number of articles in their Pocket list, user will rarely reach the end).

## Additions
- Add an article to the list even when no more article can be refined
    - For simplicity, a new list will be created with the article added as first member, then loop is recursively called (see Limitations section below for a caveat which will be addressed during a refactor)
- Also remove `break`s from switch statements since [they break by default](https://github.com/golang/go/wiki/Switch)
- Clarify some logic used for holding off on increment of article index after immediate refine (originally introduced in #32)

## Limitations
- If end of article list is reached, and user then added a new article, then any Pocket queries still pending will not have its results appended into the list (since we're recursively calling the article loop with a new list) - we'll just assume that by this point all the goroutune queries have already finished, and a refactor of this area with #42 should allow article results to be added even after a new loop is started