### PR TITLE
Add copy article URL

### DIFF
--- a/lib/utils/clipboard_utils.go
+++ b/lib/utils/clipboard_utils.go
@@ -9,6 +9,7 @@ type ClipboardManager interface {
 	GetFromClipboard() (string, error)
 	GetMostRecentlyAddedURL() string
 	SetMostRecentlyAddedURL(url string)
+	CopyToClipboard(text string) error
 }
 
 // ClipboardManagerImpl is an implementation of ClipboardManager that uses atotto's clipboard library
@@ -29,6 +30,11 @@ func (c *ClipboardManagerImpl) GetMostRecentlyAddedURL() string {
 // SetMostRecentlyAddedURL sets the URL that was most recently added
 func (c *ClipboardManagerImpl) SetMostRecentlyAddedURL(url string) {
 	c.AddedURL = url
+}
+
+// CopyToClipboard writes supplied text to the clipboard using atotto's clipboard library
+func (c *ClipboardManagerImpl) CopyToClipboard(text string) error {
+	return clipboard.WriteAll(text)
 }
 
 // IsURLInClipboard checks to see if the clipboard text is actually a URL

--- a/test/utils/clipboard_utils_test.go
+++ b/test/utils/clipboard_utils_test.go
@@ -32,6 +32,11 @@ func (m *MockClipboardManager) SetMostRecentlyAddedURL(url string) {
 	m.Called()
 }
 
+func (m *MockClipboardManager) CopyToClipboard(text string) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
 func TestIsURLInClipboardReturnsTrueForValidHTTPURL(t *testing.T) {
 	clipboardManager := &MockClipboardManager{}
 	clipboardManager.On("GetFromClipboard").Return(CLIPBOARD_HTTP_URL_STRING_FIXTURE, nil)


### PR DESCRIPTION
- Added copy command [C], which will copy article URL to clipboard
- Article can only be copied to clipboard if `Clipboard` feature is enabled in `config.yml`
- `[C]opy URL` option visible on CLI only if `Clipboard` feature is enabled
- `CopyToClipboard` method added to `ClipboardManager`, which uses atotto's clipboard library to copy string to clipboard
- Added test stub of `CopyToClipboard` method to `clipboard_utils_test`